### PR TITLE
Launch at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2] - 2021-06-11
+
+### Added
+
+- Launch at login.

--- a/LinearMouse.xcodeproj/project.pbxproj
+++ b/LinearMouse.xcodeproj/project.pbxproj
@@ -3,14 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B71392F426731645004C0173 /* LoginServiceKit in Frameworks */ = {isa = PBXBuildFile; productRef = B71392F326731645004C0173 /* LoginServiceKit */; };
 		B75A061C2671E9D800BEAF77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75A061B2671E9D800BEAF77 /* AppDelegate.swift */; };
 		B75A06202671E9DA00BEAF77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B75A061F2671E9DA00BEAF77 /* Assets.xcassets */; };
 		B75A06232671E9DA00BEAF77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B75A06222671E9DA00BEAF77 /* Preview Assets.xcassets */; };
 		B75A06262671E9DA00BEAF77 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B75A06242671E9DA00BEAF77 /* Main.storyboard */; };
+		B7BD51812672FEB5001FE742 /* ScrollWheelEventTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BD51802672FEB5001FE742 /* ScrollWheelEventTap.swift */; };
+		B7BD5183267300DC001FE742 /* AutoStartManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BD5182267300DC001FE742 /* AutoStartManager.swift */; };
+		B7DD796426730A800067F1AD /* LoginServiceKit in Frameworks */ = {isa = PBXBuildFile; productRef = B7DD796326730A800067F1AD /* LoginServiceKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +25,8 @@
 		B75A06252671E9DA00BEAF77 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		B75A06272671E9DA00BEAF77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B75A06282671E9DA00BEAF77 /* LinearMouse.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LinearMouse.entitlements; sourceTree = "<group>"; };
+		B7BD51802672FEB5001FE742 /* ScrollWheelEventTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWheelEventTap.swift; sourceTree = "<group>"; };
+		B7BD5182267300DC001FE742 /* AutoStartManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoStartManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -28,6 +34,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7DD796426730A800067F1AD /* LoginServiceKit in Frameworks */,
+				B71392F426731645004C0173 /* LoginServiceKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,6 +67,8 @@
 				B75A06272671E9DA00BEAF77 /* Info.plist */,
 				B75A06282671E9DA00BEAF77 /* LinearMouse.entitlements */,
 				B75A06212671E9DA00BEAF77 /* Preview Content */,
+				B7BD51802672FEB5001FE742 /* ScrollWheelEventTap.swift */,
+				B7BD5182267300DC001FE742 /* AutoStartManager.swift */,
 			);
 			path = LinearMouse;
 			sourceTree = "<group>";
@@ -87,6 +97,10 @@
 			dependencies = (
 			);
 			name = LinearMouse;
+			packageProductDependencies = (
+				B7DD796326730A800067F1AD /* LoginServiceKit */,
+				B71392F326731645004C0173 /* LoginServiceKit */,
+			);
 			productName = LinearMouse;
 			productReference = B75A06182671E9D800BEAF77 /* LinearMouse.app */;
 			productType = "com.apple.product-type.application";
@@ -114,6 +128,9 @@
 				Base,
 			);
 			mainGroup = B75A060F2671E9D800BEAF77;
+			packageReferences = (
+				B71392F226731645004C0173 /* XCRemoteSwiftPackageReference "LoginServiceKit" */,
+			);
 			productRefGroup = B75A06192671E9D800BEAF77 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -141,7 +158,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7BD5183267300DC001FE742 /* AutoStartManager.swift in Sources */,
 				B75A061C2671E9D800BEAF77 /* AppDelegate.swift in Sources */,
+				B7BD51812672FEB5001FE742 /* ScrollWheelEventTap.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +310,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = plus.programming.LinearMouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -313,6 +333,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = plus.programming.LinearMouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -341,6 +362,38 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B71392F226731645004C0173 /* XCRemoteSwiftPackageReference "LoginServiceKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Clipy/LoginServiceKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.1;
+			};
+		};
+		B7DD796226730A800067F1AD /* XCRemoteSwiftPackageReference "LoginServiceKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Clipy/LoginServiceKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B71392F326731645004C0173 /* LoginServiceKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B71392F226731645004C0173 /* XCRemoteSwiftPackageReference "LoginServiceKit" */;
+			productName = LoginServiceKit;
+		};
+		B7DD796326730A800067F1AD /* LoginServiceKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B7DD796226730A800067F1AD /* XCRemoteSwiftPackageReference "LoginServiceKit" */;
+			productName = LoginServiceKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B75A06102671E9D800BEAF77 /* Project object */;
 }

--- a/LinearMouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LinearMouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "LoginServiceKit",
+        "repositoryURL": "https://github.com/Clipy/LoginServiceKit",
+        "state": {
+          "branch": null,
+          "revision": "e35be754ca2409ceada3825ac80461ecbad3c11f",
+          "version": "2.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/LinearMouse/AppDelegate.swift
+++ b/LinearMouse/AppDelegate.swift
@@ -9,19 +9,7 @@ import SwiftUI
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
-    static let mouseScrollLines = Int64(3)
-
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-
-    let scrollEventCallback: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon) in
-        let isContinuous = event.getIntegerValueField(.scrollWheelEventIsContinuous)
-        // trackpad events are continuous and we simply ignore them
-        if isContinuous == 0 {
-            event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: -event.getIntegerValueField(.scrollWheelEventDeltaAxis1))
-            event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: event.getIntegerValueField(.scrollWheelEventDeltaAxis1).signum() * mouseScrollLines)
-        }
-        return Unmanaged.passUnretained(event)
-    }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         if let button = statusItem.button {
@@ -33,7 +21,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(quitMenuItem)
         statusItem.menu = menu
 
-        acquirePrivileges { self.startup() }
+        acquirePrivileges {
+            // register the start entry if the user grants the permission
+            AutoStartManager.enable()
+
+            // the core functionality
+            ScrollWheelEventTap().enable()
+        }
     }
 
     func acquirePrivileges(shouldAskForPermission: Bool = true, completion: @escaping () -> Void) {
@@ -47,22 +41,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         completion()
     }
 
-    func startup() {
-        let eventTap = CGEvent.tapCreate(
-            tap: .cghidEventTap,
-            place: .tailAppendEventTap,
-            options: .defaultTap,
-            eventsOfInterest: CGEventMask(1 << CGEventType.scrollWheel.rawValue),
-            callback: scrollEventCallback,
-            userInfo: nil
-        )
-        let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
-        CGEvent.tapEnable(tap: eventTap!, enable: true)
-        CFRunLoopRun()
-    }
 
     @objc func quit() {
+        // remove the start entry if the user quits LinearMouse manually
+        AutoStartManager.disable()
+
         NSApp.terminate(self)
     }
 }

--- a/LinearMouse/AutoStartManager.swift
+++ b/LinearMouse/AutoStartManager.swift
@@ -1,0 +1,21 @@
+//
+//  AutoStartManager.swift
+//  LinearMouse
+//
+//  Created by lujjjh on 2021/6/11.
+//
+
+import Foundation
+import LoginServiceKit
+
+class AutoStartManager {
+    @discardableResult
+    static func enable() -> Bool {
+        return LoginServiceKit.addLoginItems()
+    }
+
+    @discardableResult
+    static func disable() -> Bool {
+        return LoginServiceKit.removeLoginItems()
+    }
+}

--- a/LinearMouse/Info.plist
+++ b/LinearMouse/Info.plist
@@ -17,9 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/LinearMouse/ScrollWheelEventTap.swift
+++ b/LinearMouse/ScrollWheelEventTap.swift
@@ -1,0 +1,51 @@
+//
+//  ScrollWheelEventTap.swift
+//  LinearMouse
+//
+//  Created by lujjjh on 2021/6/11.
+//
+
+import Foundation
+
+class ScrollWheelEventTap {
+    static let mouseScrollLines = Int64(3)
+
+    var eventTap: CFMachPort?
+    var runLoopSource: CFRunLoopSource?
+
+    let scrollEventCallback: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon) in
+        let isContinuous = event.getIntegerValueField(.scrollWheelEventIsContinuous)
+        // trackpad events are continuous and we simply ignore them
+        if isContinuous == 0 {
+            event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: -event.getIntegerValueField(.scrollWheelEventDeltaAxis1))
+            event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: event.getIntegerValueField(.scrollWheelEventDeltaAxis1).signum() * mouseScrollLines)
+        }
+        return Unmanaged.passUnretained(event)
+    }
+    
+    init() {
+        eventTap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .tailAppendEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(1 << CGEventType.scrollWheel.rawValue),
+            callback: scrollEventCallback,
+            userInfo: nil
+        )
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
+        CFRunLoopRun()
+    }
+
+    func enable() {
+        if let eventTap = eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        }
+    }
+
+    func disable() {
+        if let eventTap = eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: false)
+        }
+    }
+}


### PR DESCRIPTION
For simplicity, the login entry is automatically added once LinearMouse is run and permissions are granted.

If the user manually quit LinearMouse, the login entry will be automatically removed.